### PR TITLE
add grid component

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -7,12 +7,19 @@
             <v-layer>
               <Grid :spacing="50" />
               <Point :x="10" :y="20" />
+              <ForceVector v-for="vector in forceVectors" 
+                :tail="vector.tail" 
+                :head="vector.head" 
+              />
               <!-- Add more points and arrows as needed -->
             </v-layer>
           </v-stage>
         </ClientOnly>
-        <v-btn @click="clearCanvas">
-          Clear Canvas
+        <v-btn @click="clearForceVectors">
+          Clear Vectors
+        </v-btn>
+        <v-btn @click="addForceVector">
+          Add Force Vector
         </v-btn>
       </v-container>
     </v-main>
@@ -23,12 +30,27 @@
 import { ref } from 'vue'
 import Grid from '~/components/Grid.vue'
 import Point from '~/components/Point.vue'
+import ForceVector from '~/components/ForceVector.vue'
 import { provideCanvasDimensions } from '~/composables/useCanvasDimensions'
 
 const configStage = {
   width: 500,
   height: 500,
 }
+const forceVectors = ref([])
+
+const addForceVector = () => {
+  // keeping it simple for now
+  forceVectors.value.push({ 
+    tail: { x: 0, y: 0 }, 
+    head: { x: 50, y: 50 } 
+  })
+}
+
+const clearForceVectors = () => {
+  forceVectors.value = []
+}
+
 
 // Provide canvas dimensions to all child components
 provideCanvasDimensions(configStage.width, configStage.height)

--- a/app.vue
+++ b/app.vue
@@ -3,14 +3,16 @@
     <v-main>
       <v-container>
         <ClientOnly>
-          <v-stage :config="configStage" > 
+          <v-stage :config="configStage">
             <v-layer>
-              <point v-for="gridPoint in grid" :config="gridPoint" />
+              <Grid :spacing="50" />
+              <Point :x="10" :y="20" />
+              <!-- Add more points and arrows as needed -->
             </v-layer>
           </v-stage>
         </ClientOnly>
         <v-btn @click="clearCanvas">
-            Clear Canvas
+          Clear Canvas
         </v-btn>
       </v-container>
     </v-main>
@@ -18,35 +20,18 @@
 </template>
 
 <script setup>
-import ForceVector from './components/ForceVector.vue'
-import Point from './components/Point.vue'
-const points = ref([])
-const forces = ref([])
-const grid = ref([])
+import { ref } from 'vue'
+import Grid from '~/components/Grid.vue'
+import Point from '~/components/Point.vue'
+import { provideCanvasDimensions } from '~/composables/useCanvasDimensions'
+
 const configStage = {
   width: 500,
   height: 500,
 }
 
-const drawGrid = () => {
-  for (let i = 50; i <=configStage.width; i += 50) {
-    for (let j = 50; j <= configStage.height; j += 50) {
-      const gridPoint = {
-        x: i+5,
-        y: j+5,
-      }
-      grid.value.push(gridPoint)
-    }
-  }
-}
+// Provide canvas dimensions to all child components
+provideCanvasDimensions(configStage.width, configStage.height)
 
-const clearCanvas = () => {
-  points.value = []
-  forces.value = []
-}
-
-onMounted(() => {
-  drawGrid()
-})
-  
+// ... rest of your script
 </script>

--- a/app.vue
+++ b/app.vue
@@ -21,6 +21,9 @@
         <v-btn @click="addForceVector">
           Add Force Vector
         </v-btn>
+        <v-btn @click="incrementX">
+          Increment X
+        </v-btn>
       </v-container>
     </v-main>
   </v-app>
@@ -49,6 +52,12 @@ const addForceVector = () => {
 
 const clearForceVectors = () => {
   forceVectors.value = []
+}
+
+const incrementX = () => {
+  if(forceVectors.value.length > 0) {
+    forceVectors.value[0].head.x += 50
+  }
 }
 
 

--- a/components/ForceVector.vue
+++ b/components/ForceVector.vue
@@ -1,23 +1,30 @@
 <template>
     <v-arrow :config="arrowConfig"/>
+    <v-circle 
+        :x="arrowConfig.points[2]" 
+        :y="arrowConfig.points[3]" 
+        :radius="8"
+        :fill="'red'"
+        :draggable="true"/>
 </template>
 <script setup>
 import { gridToCanvasCoordinates } from '~/utils/coordinates'
-import Point from './Point.vue'
 const props = defineProps({
     tail: {
-        type: Point,
-        required: true,
+        x: {type: Number, required: true},
+        y: {type: Number, required: true},
     },
     head: {
-        type: Point,
-        required: true,
+        x: {type: Number, required: true},
+        y: {type: Number, required: true},
     },
 })
 
 const arrowConfig = computed(() => {
-    const tailPoint = gridToCanvasCoordinates(props.tail.x, props.tail.y, props.canvasWidth, props.canvasHeight)
-    const headPoint = gridToCanvasCoordinates(props.head.x, props.head.y, props.canvasWidth, props.canvasHeight)
+/*     const tailPoint = gridToCanvasCoordinates(props.tail.x, props.tail.y)
+    const headPoint = gridToCanvasCoordinates(props.head.x, props.head.y) */
+    const tailPoint = {x: props.tail.x, y: props.tail.y}
+    const headPoint = {x: props.head.x, y: props.head.y}
     return {
     fill: 'black',
     stroke: 'black',

--- a/components/ForceVector.vue
+++ b/components/ForceVector.vue
@@ -1,34 +1,39 @@
 <template>
-    <v-arrow :config="config"/>
+    <v-arrow :config="arrowConfig"/>
 </template>
 <script setup>
+import { gridToCanvasCoordinates } from '~/utils/coordinates'
 import Point from './Point.vue'
 const props = defineProps({
-    startPoint: {
+    tail: {
         type: Point,
         required: true,
     },
-    endPoint: {
+    head: {
         type: Point,
         required: true,
     },
 })
 
-const config = {
+const arrowConfig = computed(() => {
+    const tailPoint = gridToCanvasCoordinates(props.tail.x, props.tail.y, props.canvasWidth, props.canvasHeight)
+    const headPoint = gridToCanvasCoordinates(props.head.x, props.head.y, props.canvasWidth, props.canvasHeight)
+    return {
     fill: 'black',
     stroke: 'black',
     strokeWidth: 2,
     points: [
-        props.startPoint.x, 
-        props.startPoint.y, 
-        props.endPoint.x, 
-        props.endPoint.y
+        tailPoint.x, 
+        tailPoint.y, 
+        headPoint.x, 
+        headPoint.y
     ],
 }
+})
 
 const magnitude = computed(() => {
-    const dx = props.endPoint.x - props.startPoint.x
-    const dy = props.endPoint.y - props.startPoint.y
+    const dx = props.head.x - props.tail.x
+    const dy = props.head.y - props.tail.y
     return Math.sqrt(dx * dx + dy * dy)
 })
 </script>

--- a/components/Grid.vue
+++ b/components/Grid.vue
@@ -1,0 +1,68 @@
+<template>
+    <v-group>
+      <v-circle
+        v-for="point in gridPoints"
+        :key="`${point.x},${point.y}`"
+        :config="point"
+      />
+      <v-text :config="originLabel" />
+    </v-group>
+  </template>
+  
+  <script setup>
+  import { computed } from 'vue'
+  import { gridToCanvasCoordinates } from '~/utils/coordinates'
+  
+  const props = defineProps({
+    width: { type: Number, default: 500 },
+    height: { type: Number, default: 500 },
+    spacing: { type: Number, default: 50 },
+    dotRadius: { type: Number, default: 2 },
+  })
+  
+  const gridPoints = computed(() => {
+    const points = []
+    for (let x = -Math.floor(props.width / 2); x <= Math.floor(props.width / 2); x += props.spacing) {
+      for (let y = -Math.floor(props.height / 2); y <= Math.floor(props.height / 2); y += props.spacing) {
+        const { x: canvasX, y: canvasY } = gridToCanvasCoordinates(x, y, props.width, props.height)
+        points.push({
+          x: canvasX,
+          y: canvasY,
+          radius: props.dotRadius,
+          fill: 'lightgray',
+        })
+      }
+    }
+    return points
+  })
+  
+  const originLabel = computed(() => {
+    const { x, y } = gridToCanvasCoordinates(5, -5, props.width, props.height)
+    return {
+      x,
+      y,
+      text: '0,0',
+      fontSize: 12,
+      fill: 'red',
+    }
+  })
+  
+  const coordinateLabels = computed(() => {
+    const labels = []
+    for (let x = -Math.floor(props.width / 2); x <= Math.floor(props.width / 2); x += props.spacing) {
+      for (let y = -Math.floor(props.height / 2); y <= Math.floor(props.height / 2); y += props.spacing) {
+        if (x !== 0 || y !== 0) {
+          const { x: canvasX, y: canvasY } = gridToCanvasCoordinates(x + 5, y - 5, props.width, props.height)
+          labels.push({
+            x: canvasX,
+            y: canvasY,
+            text: `${x / props.spacing},${y / props.spacing}`,
+            fontSize: 10,
+            fill: 'blue',
+          })
+        }
+      }
+    }
+    return labels
+  })
+  </script>

--- a/components/Grid.vue
+++ b/components/Grid.vue
@@ -17,7 +17,7 @@
     width: { type: Number, default: 500 },
     height: { type: Number, default: 500 },
     spacing: { type: Number, default: 50 },
-    dotRadius: { type: Number, default: 2 },
+    dotRadius: { type: Number, default: 4 },
   })
   
   const gridPoints = computed(() => {
@@ -29,7 +29,7 @@
           x: canvasX,
           y: canvasY,
           radius: props.dotRadius,
-          fill: 'lightgray',
+          fill: x === 0 && y === 0 ? 'red' : 'lightgray',
         })
       }
     }
@@ -38,20 +38,22 @@
   
   const originLabel = computed(() => {
     const { x, y } = gridToCanvasCoordinates(5, -5, props.width, props.height)
+    if (x === 0 && y === 0) {
     return {
       x,
       y,
       text: '0,0',
       fontSize: 12,
       fill: 'red',
-    }
+    }}
+    return null
   })
   
   const coordinateLabels = computed(() => {
     const labels = []
     for (let x = -Math.floor(props.width / 2); x <= Math.floor(props.width / 2); x += props.spacing) {
       for (let y = -Math.floor(props.height / 2); y <= Math.floor(props.height / 2); y += props.spacing) {
-        if (x !== 0 || y !== 0) {
+        if (x == 0 && y == 0) {
           const { x: canvasX, y: canvasY } = gridToCanvasCoordinates(x + 5, y - 5, props.width, props.height)
           labels.push({
             x: canvasX,

--- a/components/Grid.vue
+++ b/components/Grid.vue
@@ -5,7 +5,6 @@
         :key="`${point.x},${point.y}`"
         :config="point"
       />
-      <v-text :config="originLabel" />
     </v-group>
   </template>
   
@@ -36,35 +35,7 @@
     return points
   })
   
-  const originLabel = computed(() => {
-    const { x, y } = gridToCanvasCoordinates(5, -5, props.width, props.height)
-    if (x === 0 && y === 0) {
-    return {
-      x,
-      y,
-      text: '0,0',
-      fontSize: 12,
-      fill: 'red',
-    }}
-    return null
-  })
+ 
   
-  const coordinateLabels = computed(() => {
-    const labels = []
-    for (let x = -Math.floor(props.width / 2); x <= Math.floor(props.width / 2); x += props.spacing) {
-      for (let y = -Math.floor(props.height / 2); y <= Math.floor(props.height / 2); y += props.spacing) {
-        if (x == 0 && y == 0) {
-          const { x: canvasX, y: canvasY } = gridToCanvasCoordinates(x + 5, y - 5, props.width, props.height)
-          labels.push({
-            x: canvasX,
-            y: canvasY,
-            text: `${x / props.spacing},${y / props.spacing}`,
-            fontSize: 10,
-            fill: 'blue',
-          })
-        }
-      }
-    }
-    return labels
-  })
+
   </script>

--- a/components/Grid.vue
+++ b/components/Grid.vue
@@ -5,6 +5,12 @@
         :key="`${point.x},${point.y}`"
         :config="point"
       />
+      <v-text :config="originLabel" />
+      <v-text
+      v-for="label in axisLabels"
+      :key="label.text"
+      :config="label"
+    />
     </v-group>
   </template>
   
@@ -35,7 +41,48 @@
     return points
   })
   
+  const { width, height } = useCanvasDimensions().value
+
+  const originLabel = computed(() => {
+  const { x, y } = gridToCanvasCoordinates(5, -5)
+  return {
+    x,
+    y,
+    text: '(0,0)',
+    fontSize: 12,
+    fill: 'red',
+  }
+})
  
-  
+const axisLabels = computed(() => {
+  const labels = []
+  for (let x = -Math.floor(width / 2); x <= Math.floor(width / 2); x += props.spacing) {
+    if (x !== 0) {
+      const { x: canvasX, y: canvasY } = gridToCanvasCoordinates(x, 0)
+      labels.push({
+        x: canvasX,
+        y: canvasY + 15,
+        text: x.toString(),
+        fontSize: 10,
+        fill: 'blue',
+        align: 'center',
+      })
+    }
+  }
+  for (let y = -Math.floor(height / 2); y <= Math.floor(height / 2); y += props.spacing) {
+    if (y !== 0) {
+      const { x: canvasX, y: canvasY } = gridToCanvasCoordinates(0, y)
+      labels.push({
+        x: canvasX - 15,
+        y: canvasY,
+        text: y.toString(),
+        fontSize: 10,
+        fill: 'blue',
+        align: 'right',
+      })
+    }
+  }
+  return labels
+})  
 
   </script>

--- a/components/Point.vue
+++ b/components/Point.vue
@@ -1,39 +1,27 @@
 <template>
-    <v-circle :config="config"/>
-</template>
-
-<script setup>
-const props = defineProps({
-    config: {
-    x: {
-        type: Number,
-        required: true,
-    },
-    y: {
-        type: Number,
-        required: true,
-    },
-    radius: {
-        type: Number,
-        default: 5,
-    },
-    fill: {
-        type: String,
-        default: 'lightgrey',
-    },
-    }
-})
-
-const config = computed(() => {
+    <v-circle :config="circleConfig" />
+  </template>
+  
+  <script setup>
+  import { computed } from 'vue'
+  import { gridToCanvasCoordinates } from '~/utils/coordinates'
+  
+  const props = defineProps({
+    x: { type: Number, required: true },
+    y: { type: Number, required: true },
+    radius: { type: Number, default: 5 },
+    fill: { type: String, default: 'red' },
+    canvasWidth: { type: Number, required: true },
+    canvasHeight: { type: Number, required: true },
+  })
+  
+  const circleConfig = computed(() => {
+    const { x, y } = gridToCanvasCoordinates(props.x, props.y, props.canvasWidth, props.canvasHeight)
     return {
-        x: props.config.x,
-        y: props.config.y,
-        radius: props.config.radius ?? 5,
-        fill: props.config.fill ?? 'lightgrey',
+      x,
+      y,
+      radius: props.radius,
+      fill: props.fill,
     }
-})
-
-onMounted(() => {
-    console.log(`POINT CREATED ${props.config.radius} ${props.config.fill}`)
-})
-</script>
+  })
+  </script>

--- a/composables/useCanvasDimensions.js
+++ b/composables/useCanvasDimensions.js
@@ -1,0 +1,16 @@
+import { provide, inject, ref } from 'vue'
+
+const canvasDimensionsSymbol = Symbol()
+
+export function provideCanvasDimensions(width, height) {
+    const dimensions = ref({ width, height })
+    provide(canvasDimensionsSymbol, dimensions)
+}
+
+export function useCanvasDimensions() {
+    const dimensions = inject(canvasDimensionsSymbol)
+    if (!dimensions) {
+        throw new Error('Canvas dimensions not provided')
+    }
+    return dimensions
+}

--- a/utils/coordinates.js
+++ b/utils/coordinates.js
@@ -1,0 +1,11 @@
+import { useCanvasDimensions } from '~/composables/useCanvasDimensions'
+
+export function gridToCanvasCoordinates(x, y) {
+    const { width, height } = useCanvasDimensions().value
+    const centerX = Math.floor(width / 2)
+    const centerY = Math.floor(height / 2)
+    return {
+        x: centerX + x,
+        y: centerY - y  // Subtract y because canvas Y increases downwards
+    }
+}


### PR DESCRIPTION
- Adds a grid component and util function to translate between grid coords with origin at 0,0 in center of screen and canvas cordinates with origin in the top right corner. 
- Modifies point component to take coordinate inputs as grid components

Todo: 
- fix the partial rendering of grid points on the boundary
- think about what do do if you pan or zoom the screen (later feature)