### PR TITLE
feat/add-modify-force-vectors

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -47,7 +47,6 @@ const addForceVector = () => {
   forceVectors.value.push({ 
     tail: { x: 0, y: 0 }, 
     head: { x: 50, y: 50 },
-    id: Math.random().toString(36).substring(2, 6)
   })
 }
 

--- a/app.vue
+++ b/app.vue
@@ -8,12 +8,11 @@
               <v-stage :config="configStage">
                 <v-layer>
                   <Grid :spacing="50" />
-                  <ForceVector v-for="vector in forceVectors" :key="vectorIndex"
+                  <ForceVector v-for="vector in forceVectors" :key="vector.Grid"
                     :tail="vector.tail" 
                     :head="vector.head" 
                     :showComponents="showComponents"
                     :id="vector.id"
-                    @dragEnd="handleDragEnd"
                   />  
                 </v-layer>
               </v-stage>
@@ -25,12 +24,11 @@
                 <v-layer>
                   <Grid :spacing="50" />
                   <ForceVector v-for="vector in cumulativeVectors" 
-                    :key="vectorIndex"
+                    :key="vector.id"
                     :tail="vector.tail" 
                     :head="vector.head" 
                     :id="vector.id"
                     :showComponents="showComponents"
-                    @dragEnd="handleDragEnd"
                   />  
                 </v-layer>
               </v-stage>
@@ -66,32 +64,19 @@ const configStage = {
   height: 500,
 }
 const forceVectors = ref([])
-const vectorIndex = ref(0)
 
 const addForceVector = () => {
   forceVectors.value.push({ 
     id: Date.now().toString(),
-    tail: { x: 250, y: 250 }, 
-    head: { x: 250, y: 100 } 
+    tail: { x: 0 , y: 0 }, 
+    head: { x: 100, y:200 } 
   })
-  vectorIndex.value++
 }
 
 const clearForceVectors = () => {
   forceVectors.value = []
 }
 
-//necessary for ensuring the draggable circle snaps back to the vector head
-const handleDragEnd = (vector) => {
-  forceVectors.value = forceVectors.value.map((v) => {
-    if (v.id === vector.id) {
-      v.head = vector.head
-      v.tail = vector.tail
-    }
-    return v
-  })
-  vectorIndex.value++
-}
 
 const cumulativeVectors = computed(() => {
   let cumulative = { x: 250, y: 250 } //needed at 250,250 until we can figure out the issue with gridToCanvasCoordinates

--- a/app.vue
+++ b/app.vue
@@ -6,7 +6,6 @@
           <v-stage :config="configStage">
             <v-layer>
               <Grid :spacing="50" />
-              <Point :x="10" :y="20" />
               <ForceVector v-for="vector in forceVectors" 
                 :tail="vector.tail" 
                 :head="vector.head" 

--- a/app.vue
+++ b/app.vue
@@ -6,9 +6,11 @@
           <v-stage :config="configStage">
             <v-layer>
               <Grid :spacing="50" />
-              <ForceVector v-for="vector in forceVectors" :key="vector.id"
+              <ForceVector v-for="vector in forceVectors" :key="vectorIndex"
                 :tail="vector.tail" 
                 :head="vector.head" 
+                :id="vector.id"
+                @dragEnd="handleDragEnd" 
               />
               <!-- Add more points and arrows as needed -->
             </v-layer>
@@ -40,17 +42,31 @@ const configStage = {
   height: 500,
 }
 const forceVectors = ref([])
+const vectorIndex = ref(0)
 
 const addForceVector = () => {
   // keeping it simple for now
   forceVectors.value.push({ 
-    tail: { x: 0, y: 0 }, 
-    head: { x: 50, y: 50 },
+    tail: { x: 250, y: 250 }, 
+    head: { x: 250, y: 100 },
+    id: Math.random().toString(36).substring(2, 8)
   })
+  vectorIndex.value++
 }
 
 const clearForceVectors = () => {
   forceVectors.value = []
+}
+
+const handleDragEnd = (vector) => {
+  forceVectors.value = forceVectors.value.map((v) => {
+    if (v.id === vector.id) {
+      v.head = vector.head
+      v.tail = vector.tail
+    }
+    console.log(forceVectors.value)
+    return v
+  })
 }
 
 // Provide canvas dimensions to all child components

--- a/app.vue
+++ b/app.vue
@@ -22,9 +22,6 @@
         <v-btn @click="addForceVector">
           Add Force Vector
         </v-btn>
-        <p>
-          vectors: {{ forceVectors }}
-        </p>
       </v-container>
     </v-main>
   </v-app>

--- a/app.vue
+++ b/app.vue
@@ -92,10 +92,6 @@ const handleDragEnd = (vector) => {
   })
   vectorIndex.value++
 }
-const toggleShowComponents = () => {
-  console.log('toggleShowComponents', showComponents.value)
-  showComponents.value = !showComponents.value
-}
 
 const cumulativeVectors = computed(() => {
   let cumulative = { x: 250, y: 250 } //needed at 250,250 until we can figure out the issue with gridToCanvasCoordinates

--- a/app.vue
+++ b/app.vue
@@ -67,6 +67,7 @@ const handleDragEnd = (vector) => {
     console.log(forceVectors.value)
     return v
   })
+  vectorIndex.value++
 }
 
 // Provide canvas dimensions to all child components

--- a/app.vue
+++ b/app.vue
@@ -115,6 +115,4 @@ const cumulativeVectors = computed(() => {
 
 // Provide canvas dimensions to all child components
 provideCanvasDimensions(configStage.width, configStage.height)
-
-// ... rest of your script
 </script>

--- a/app.vue
+++ b/app.vue
@@ -6,9 +6,10 @@
           <v-stage :config="configStage">
             <v-layer>
               <Grid :spacing="50" />
-              <ForceVector v-for="vector in forceVectors" 
+              <ForceVector v-for="vector in forceVectors" :key="vector.id"
                 :tail="vector.tail" 
                 :head="vector.head" 
+                :id="vector.id"
               />
               <!-- Add more points and arrows as needed -->
             </v-layer>
@@ -20,6 +21,9 @@
         <v-btn @click="addForceVector">
           Add Force Vector
         </v-btn>
+        <p>
+          vectors: {{ forceVectors }}
+        </p>
       </v-container>
     </v-main>
   </v-app>
@@ -42,7 +46,8 @@ const addForceVector = () => {
   // keeping it simple for now
   forceVectors.value.push({ 
     tail: { x: 0, y: 0 }, 
-    head: { x: 50, y: 50 } 
+    head: { x: 50, y: 50 },
+    id: Math.random().toString(36).substring(2, 6)
   })
 }
 

--- a/app.vue
+++ b/app.vue
@@ -9,7 +9,6 @@
               <ForceVector v-for="vector in forceVectors" :key="vector.id"
                 :tail="vector.tail" 
                 :head="vector.head" 
-                :id="vector.id"
               />
               <!-- Add more points and arrows as needed -->
             </v-layer>

--- a/app.vue
+++ b/app.vue
@@ -20,9 +20,6 @@
         <v-btn @click="addForceVector">
           Add Force Vector
         </v-btn>
-        <v-btn @click="incrementX">
-          Increment X
-        </v-btn>
       </v-container>
     </v-main>
   </v-app>
@@ -52,13 +49,6 @@ const addForceVector = () => {
 const clearForceVectors = () => {
   forceVectors.value = []
 }
-
-const incrementX = () => {
-  if(forceVectors.value.length > 0) {
-    forceVectors.value[0].head.x += 50
-  }
-}
-
 
 // Provide canvas dimensions to all child components
 provideCanvasDimensions(configStage.width, configStage.height)

--- a/app.vue
+++ b/app.vue
@@ -100,20 +100,18 @@ const toggleShowComponents = () => {
   showComponents.value = !showComponents.value
 }
 
-const canvasCorrection = 250 //needed until we can figure out the issue with gridToCanvasCoordinates
 const cumulativeVectors = computed(() => {
-  let cumulative = { x: 0, y: 0 }
+  let cumulative = { x: 250, y: 250 } //needed at 250,250 until we can figure out the issue with gridToCanvasCoordinates
   return forceVectors.value.map(v => {
     const newVector = {
       id: `cumulative-${v.id}`,
-      tail: { x: cumulative.x + canvasCorrection, y: cumulative.y + canvasCorrection },
+      tail: { x: cumulative.x, y: cumulative.y },
       head: { 
-        x: cumulative.x + (v.head.x - v.tail.x) + canvasCorrection,
-        y: cumulative.y + (v.head.y - v.tail.y) + canvasCorrection
+        x: cumulative.x + (v.head.x - v.tail.x),
+        y: cumulative.y + (v.head.y - v.tail.y)
       }
     }
     cumulative = newVector.head
-    console.log('newVector', newVector)
     return newVector
   })
 })

--- a/app.vue
+++ b/app.vue
@@ -47,9 +47,6 @@
           v-model="showComponents"
           label="Show Vector Components"
         ></v-checkbox>
-        <p v-for="vector in forceVectors" :key="vector.id">
-          {{ vector }}
-        </p>
       </v-container>
     </v-main>
   </v-app>

--- a/app.vue
+++ b/app.vue
@@ -45,7 +45,6 @@ const forceVectors = ref([])
 const vectorIndex = ref(0)
 
 const addForceVector = () => {
-  // keeping it simple for now
   forceVectors.value.push({ 
     tail: { x: 250, y: 250 }, 
     head: { x: 250, y: 100 },
@@ -58,6 +57,7 @@ const clearForceVectors = () => {
   forceVectors.value = []
 }
 
+//necessary for ensuring the draggable circle snaps back to the vector head
 const handleDragEnd = (vector) => {
   forceVectors.value = forceVectors.value.map((v) => {
     if (v.id === vector.id) {

--- a/app.vue
+++ b/app.vue
@@ -49,7 +49,7 @@ const addForceVector = () => {
   forceVectors.value.push({ 
     tail: { x: 250, y: 250 }, 
     head: { x: 250, y: 100 },
-    id: Math.random().toString(36).substring(2, 8)
+    id: Date.now()
   })
   vectorIndex.value++
 }

--- a/app.vue
+++ b/app.vue
@@ -79,7 +79,7 @@ const clearForceVectors = () => {
 
 
 const cumulativeVectors = computed(() => {
-  let cumulative = { x: 250, y: 250 } //needed at 250,250 until we can figure out the issue with gridToCanvasCoordinates
+  let cumulative = { x: 0, y: 0 }
   return forceVectors.value.map(v => {
     const newVector = {
       id: `cumulative-${v.id}`,

--- a/components/ForceVector.vue
+++ b/components/ForceVector.vue
@@ -53,8 +53,7 @@ const dragCircle = (event) => {
 }
 
 const arrowConfig = computed(() => {
-/*     const tailPoint = gridToCanvasCoordinates(props.tail.x, props.tail.y)
-    const headPoint = gridToCanvasCoordinates(props.head.x, props.head.y) */
+    //convert to use gridToCoordinate function when fixed
     const tailPoint = {
         x: props.tail.x,
         y: props.tail.y

--- a/components/ForceVector.vue
+++ b/components/ForceVector.vue
@@ -32,7 +32,10 @@ const dragCircle = (event) => {
     if(pointerPosition.x % 50 <= 15 || pointerPosition.y % 50 <= 15) {
         arrowConfig.value.points[2] = Math.round(pointerPosition.x / 50) * 50
         arrowConfig.value.points[3] = Math.round(pointerPosition.y / 50) * 50
-        magnitude.value = calculateMagnitude(arrowConfig.value.points[2] - arrowConfig.value.points[0], arrowConfig.value.points[3] - arrowConfig.value.points[1])
+        magnitude.value = calculateMagnitude(
+            arrowConfig.value.points[2] - arrowConfig.value.points[0], 
+            arrowConfig.value.points[3] - arrowConfig.value.points[1]
+        )
     }
 }
 
@@ -57,6 +60,9 @@ const calculateMagnitude = (x, y) => {
 }
 
 onMounted(() => {
-    magnitude.value = calculateMagnitude(arrowConfig.value.points[2] - arrowConfig.value.points[0], arrowConfig.value.points[3] - arrowConfig.value.points[1])
+    magnitude.value = calculateMagnitude(
+        arrowConfig.value.points[2] - arrowConfig.value.points[0], 
+        arrowConfig.value.points[3] - arrowConfig.value.points[1]
+    )
 })
 </script>

--- a/components/ForceVector.vue
+++ b/components/ForceVector.vue
@@ -8,11 +8,13 @@
         :fill="'black'"
         :draggable="true"
         @dragmove="dragCircle"
+        @dragend="dragEnd"
         />
 </template>
 <script setup>
 import { gridToCanvasCoordinates } from '~/utils/coordinates'
 
+const emit = defineEmits(['dragEnd'])
 const magnitude = ref(0)
 const props = defineProps({
     tail: {
@@ -23,25 +25,39 @@ const props = defineProps({
         x: {type: Number, required: true},
         y: {type: Number, required: true},
     },
+    id: {
+        type: String,
+        required: true
+    }
 })
 
 const dragCircle = (event) => {
     const stage = event.target.getStage()
     const pointerPosition = stage.getPointerPosition()
-
-    if(pointerPosition.x % 50 <= 15 || pointerPosition.y % 50 <= 15) {
+    const snapTolerance = 15
+    
+    if(pointerPosition.x % 50 <= snapTolerance || pointerPosition.y % 50 <= snapTolerance) {
         arrowConfig.value.points[2] = Math.round(pointerPosition.x / 50) * 50
         arrowConfig.value.points[3] = Math.round(pointerPosition.y / 50) * 50
         magnitude.value = calculateMagnitude(
             arrowConfig.value.points[2] - arrowConfig.value.points[0], 
             arrowConfig.value.points[3] - arrowConfig.value.points[1]
         )
+        
     }
 }
 
 const arrowConfig = computed(() => {
-    const tailPoint = gridToCanvasCoordinates(props.tail.x, props.tail.y)
-    const headPoint = gridToCanvasCoordinates(props.head.x, props.head.y)
+/*     const tailPoint = gridToCanvasCoordinates(props.tail.x, props.tail.y)
+    const headPoint = gridToCanvasCoordinates(props.head.x, props.head.y) */
+    const tailPoint = {
+        x: props.tail.x,
+        y: props.tail.y
+    }
+    const headPoint = {
+        x: props.head.x,
+        y: props.head.y
+    }
     return {
     fill: 'black',
     stroke: 'black',
@@ -55,6 +71,20 @@ const arrowConfig = computed(() => {
 }
 })
 
+const dragEnd = () => {
+    const vector = {
+        tail: {
+            x: arrowConfig.value.points[0],
+            y: arrowConfig.value.points[1],
+        },
+        head: {
+            x: arrowConfig.value.points[2],
+            y: arrowConfig.value.points[3],
+        },
+        id: props.id
+    }
+    emit('dragEnd', vector)
+}
 const calculateMagnitude = (x, y) => {
     return Math.sqrt(x * x + y * y)
 }

--- a/components/ForceVector.vue
+++ b/components/ForceVector.vue
@@ -29,8 +29,6 @@ const dragCircle = (event) => {
 }
 
 const arrowConfig = computed(() => {
-/*     const tailPoint = gridToCanvasCoordinates(props.tail.x, props.tail.y)
-    const headPoint = gridToCanvasCoordinates(props.head.x, props.head.y) */
     const tailPoint = gridToCanvasCoordinates(props.tail.x, props.tail.y)
     const headPoint = gridToCanvasCoordinates(props.head.x, props.head.y)
     return {

--- a/components/ForceVector.vue
+++ b/components/ForceVector.vue
@@ -8,7 +8,6 @@
         :fill="'black'"
         :draggable="true"
         @dragmove="dragCircle"
-        @mouseup="onDragEnd"
         />
 </template>
 <script setup>
@@ -39,11 +38,6 @@ const dragCircle = (event) => {
         )
     }
 }
-
-const onDragEnd = (event) => {
-    
-}
-
 
 const arrowConfig = computed(() => {
     const tailPoint = gridToCanvasCoordinates(props.tail.x, props.tail.y)

--- a/components/ForceVector.vue
+++ b/components/ForceVector.vue
@@ -10,8 +10,10 @@
         @dragmove="dragCircle"
         @dragend="dragEnd"
         />
-    <v-arrow v-if="props.showComponents" :config="xComponentConfig"/>
-    <v-arrow v-if="props.showComponents" :config="yComponentConfig"/>
+    <div v-if="props.showComponents && hasNoZeroComponents">
+        <v-arrow :config="xComponentConfig"/>
+        <v-arrow :config="yComponentConfig"/>
+    </div>
 </template>
 
 <script setup>
@@ -149,6 +151,12 @@ const yComponentConfig = computed(() => {
             headPoint.y
         ],
     } */
+})
+
+const hasNoZeroComponents = computed(()=>{
+    const isXComponentZero = Math.abs(props.head.y - props.tail.y) > 0
+    const isYComponentZero = Math.abs(props.head.x - props.tail.x) > 0
+    return isXComponentZero && isYComponentZero
 })
 
 //necessary for ensuring the draggable circle snaps back to the vector head

--- a/components/ForceVector.vue
+++ b/components/ForceVector.vue
@@ -10,6 +10,8 @@
 </template>
 <script setup>
 import { gridToCanvasCoordinates } from '~/utils/coordinates'
+
+const magnitude = ref(0)
 const props = defineProps({
     tail: {
         x: {type: Number, required: true},
@@ -26,6 +28,7 @@ const dragCircle = (event) => {
     const pointerPosition = stage.getPointerPosition()
     arrowConfig.value.points[2] = pointerPosition.x
     arrowConfig.value.points[3] = pointerPosition.y
+    magnitude.value = calculateMagnitude(arrowConfig.value.points[2] - arrowConfig.value.points[0], arrowConfig.value.points[3] - arrowConfig.value.points[1])
 }
 
 const arrowConfig = computed(() => {
@@ -44,9 +47,11 @@ const arrowConfig = computed(() => {
 }
 })
 
-const magnitude = computed(() => {
-    const dx = arrowConfig.value.points[2] - arrowConfig.value.points[0]
-    const dy = arrowConfig.value.points[3] - arrowConfig.value.points[1]
-    return Math.sqrt(dx * dx + dy * dy)
+const calculateMagnitude = (x, y) => {
+    return Math.sqrt(x * x + y * y)
+}
+
+onMounted(() => {
+    magnitude.value = calculateMagnitude(arrowConfig.value.points[2] - arrowConfig.value.points[0], arrowConfig.value.points[3] - arrowConfig.value.points[1])
 })
 </script>

--- a/components/ForceVector.vue
+++ b/components/ForceVector.vue
@@ -4,7 +4,7 @@
         :x="arrowConfig.points[2]" 
         :y="arrowConfig.points[3]" 
         :radius="15"
-        :opacity="0.5"
+        :opacity="0"
         :fill="'black'"
         :draggable="true"
         @dragmove="dragCircle"
@@ -77,8 +77,7 @@ const arrowConfig = computed(() => {
 })
 
 const xComponentConfig = computed(() => {
-/*     const tailPoint = gridToCanvasCoordinates(props.tail.x, props.tail.y)
-    const headPoint = gridToCanvasCoordinates(props.head.x, props.head.y) */
+    //implementation using commented section below can be used once gridToCoordinate issues are resolved
     const tailPoint = {
         x: props.tail.x,
         y: props.tail.y
@@ -96,14 +95,27 @@ const xComponentConfig = computed(() => {
             tailPoint.x,
             tailPoint.y,
             headPoint.x,
-            headPoint.y
+            tailPoint.y
         ],
     }
+/*     const tailPoint = gridToCanvasCoordinates(props.tail.x, props.tail.y)
+    const headPoint = gridToCanvasCoordinates(props.head.x, props.tail.y)
+    return {
+        fill: 'blue',
+        stroke: 'blue',
+        strokeWidth: 1,
+        dash: [5, 5],
+        points: [
+            tailPoint.x,
+            tailPoint.y,
+            headPoint.x,
+            headPoint.y
+        ],
+    } */
 })
 
 const yComponentConfig = computed(() => {
-/*     const tailPoint = gridToCanvasCoordinates(props.tail.x, props.tail.y)
-    const headPoint = gridToCanvasCoordinates(props.head.x, props.head.y) */
+    //implementation using commented section below can be used once gridToCoordinate issues are resolved
     const tailPoint = {
         x: props.tail.x,
         y: props.tail.y
@@ -118,12 +130,26 @@ const yComponentConfig = computed(() => {
         strokeWidth: 1,
         dash: [5, 5],
         points: [
-            tailPoint.x,
+            headPoint.x,
             tailPoint.y,
             headPoint.x,
             headPoint.y
         ],
     }
+/*     const tailPoint = gridToCanvasCoordinates(props.head.x, props.tail.y)
+    const headPoint = gridToCanvasCoordinates(props.head.x, props.head.y)
+    return {
+        fill: 'green',
+        stroke: 'green',
+        strokeWidth: 1,
+        dash: [5, 5],
+        points: [
+            tailPoint.x,
+            tailPoint.y,
+            headPoint.x,
+            headPoint.y
+        ],
+    } */
 })
 
 //necessary for ensuring the draggable circle snaps back to the vector head

--- a/components/ForceVector.vue
+++ b/components/ForceVector.vue
@@ -3,9 +3,10 @@
     <v-circle 
         :x="arrowConfig.points[2]" 
         :y="arrowConfig.points[3]" 
-        :radius="8"
-        :fill="'red'"
-        :draggable="true"/>
+        :radius="10"
+        :opacity="0"
+        :draggable="true"
+        @dragmove="dragCircle"/>
 </template>
 <script setup>
 import { gridToCanvasCoordinates } from '~/utils/coordinates'
@@ -19,6 +20,13 @@ const props = defineProps({
         y: {type: Number, required: true},
     },
 })
+
+const dragCircle = (event) => {
+    const stage = event.target.getStage()
+    const pointerPosition = stage.getPointerPosition()
+    arrowConfig.value.points[2] = pointerPosition.x
+    arrowConfig.value.points[3] = pointerPosition.y
+}
 
 const arrowConfig = computed(() => {
 /*     const tailPoint = gridToCanvasCoordinates(props.tail.x, props.tail.y)
@@ -39,8 +47,8 @@ const arrowConfig = computed(() => {
 })
 
 const magnitude = computed(() => {
-    const dx = props.head.x - props.tail.x
-    const dy = props.head.y - props.tail.y
+    const dx = arrowConfig.value.points[2] - arrowConfig.value.points[0]
+    const dy = arrowConfig.value.points[3] - arrowConfig.value.points[1]
     return Math.sqrt(dx * dx + dy * dy)
 })
 </script>

--- a/components/ForceVector.vue
+++ b/components/ForceVector.vue
@@ -22,6 +22,7 @@ import { useCanvasDimensions } from '~/composables/useCanvasDimensions'
 import { gridToCanvasCoordinates, canvasToGridCoordinates } from '~/utils/coordinates';
 
 const { width, height } = useCanvasDimensions()
+const SNAP_TOLERANCE = 15
 
 const props = defineProps({
     tail: {
@@ -76,15 +77,13 @@ watch(() => props.initialHead, (newHead) => {
 const dragCircle = (event) => {
     const stage = event.target.getStage()
     const pointerPosition = stage.getPointerPosition() // canvas coords
-    const snapTolerance = 15
     
     // Round to nearest 50
     const snappedX = Math.round(pointerPosition.x / 50) * 50
     const snappedY = Math.round(pointerPosition.y / 50) * 50
     
-    // Check if we should snap
-    const shouldSnapX = Math.abs(pointerPosition.x - snappedX) <= snapTolerance
-    const shouldSnapY = Math.abs(pointerPosition.y - snappedY) <= snapTolerance
+    const shouldSnapX = Math.abs(pointerPosition.x - snappedX) <= SNAP_TOLERANCE
+    const shouldSnapY = Math.abs(pointerPosition.y - snappedY) <= SNAP_TOLERANCE
     
     const gridCoords = canvasToGridCoordinates(
         shouldSnapX ? snappedX : pointerPosition.x,

--- a/components/ForceVector.vue
+++ b/components/ForceVector.vue
@@ -71,6 +71,7 @@ const arrowConfig = computed(() => {
 }
 })
 
+//necessary for ensuring the draggable circle snaps back to the vector head
 const dragEnd = () => {
     const vector = {
         tail: {

--- a/components/ForceVector.vue
+++ b/components/ForceVector.vue
@@ -3,7 +3,7 @@
     <v-circle 
         :x="arrowConfig.points[2]" 
         :y="arrowConfig.points[3]" 
-        :radius="13"
+        :radius="15"
         :opacity="0"
         :fill="'black'"
         :draggable="true"

--- a/components/ForceVector.vue
+++ b/components/ForceVector.vue
@@ -4,7 +4,7 @@
         :x="arrowConfig.points[2]" 
         :y="arrowConfig.points[3]" 
         :radius="13"
-        :opacity="0.5"
+        :opacity="0"
         :fill="'black'"
         :draggable="true"
         @dragmove="dragCircle"

--- a/components/ForceVector.vue
+++ b/components/ForceVector.vue
@@ -3,10 +3,12 @@
     <v-circle 
         :x="arrowConfig.points[2]" 
         :y="arrowConfig.points[3]" 
-        :radius="10"
-        :opacity="0"
+        :radius="13"
+        :opacity="0.5"
+        :fill="'black'"
         :draggable="true"
-        @dragmove="dragCircle"/>
+        @dragmove="dragCircle"
+        />
 </template>
 <script setup>
 import { gridToCanvasCoordinates } from '~/utils/coordinates'
@@ -26,9 +28,12 @@ const props = defineProps({
 const dragCircle = (event) => {
     const stage = event.target.getStage()
     const pointerPosition = stage.getPointerPosition()
-    arrowConfig.value.points[2] = pointerPosition.x
-    arrowConfig.value.points[3] = pointerPosition.y
-    magnitude.value = calculateMagnitude(arrowConfig.value.points[2] - arrowConfig.value.points[0], arrowConfig.value.points[3] - arrowConfig.value.points[1])
+
+    if(pointerPosition.x % 50 <= 15 || pointerPosition.y % 50 <= 15) {
+        arrowConfig.value.points[2] = Math.round(pointerPosition.x / 50) * 50
+        arrowConfig.value.points[3] = Math.round(pointerPosition.y / 50) * 50
+        magnitude.value = calculateMagnitude(arrowConfig.value.points[2] - arrowConfig.value.points[0], arrowConfig.value.points[3] - arrowConfig.value.points[1])
+    }
 }
 
 const arrowConfig = computed(() => {

--- a/components/ForceVector.vue
+++ b/components/ForceVector.vue
@@ -24,10 +24,6 @@ const props = defineProps({
         x: {type: Number, required: true},
         y: {type: Number, required: true},
     },
-    id: {
-        type: String,
-        required: true
-    }
 })
 
 const dragCircle = (event) => {

--- a/components/ForceVector.vue
+++ b/components/ForceVector.vue
@@ -8,6 +8,7 @@
         :fill="'black'"
         :draggable="true"
         @dragmove="dragCircle"
+        @mouseup="onDragEnd"
         />
 </template>
 <script setup>
@@ -23,6 +24,10 @@ const props = defineProps({
         x: {type: Number, required: true},
         y: {type: Number, required: true},
     },
+    id: {
+        type: String,
+        required: true
+    }
 })
 
 const dragCircle = (event) => {
@@ -38,6 +43,11 @@ const dragCircle = (event) => {
         )
     }
 }
+
+const onDragEnd = (event) => {
+    
+}
+
 
 const arrowConfig = computed(() => {
     const tailPoint = gridToCanvasCoordinates(props.tail.x, props.tail.y)

--- a/components/Grid.vue
+++ b/components/Grid.vue
@@ -5,12 +5,12 @@
         :key="`${point.x},${point.y}`"
         :config="point"
       />
-      <v-text :config="originLabel" />
+<!--       <v-text :config="originLabel" />
       <v-text
       v-for="label in axisLabels"
       :key="label.text"
       :config="label"
-    />
+    /> -->
     </v-group>
   </template>
   

--- a/composables/useCanvasDimensions.js
+++ b/composables/useCanvasDimensions.js
@@ -10,7 +10,8 @@ export function provideCanvasDimensions(width, height) {
 export function useCanvasDimensions() {
     const dimensions = inject(canvasDimensionsSymbol)
     if (!dimensions) {
-        throw new Error('Canvas dimensions not provided')
+        console.warn('Canvas dimensions not provided, using default values')
+        return ref({ width: 500, height: 500 })
     }
     return dimensions
 }

--- a/utils/coordinates.js
+++ b/utils/coordinates.js
@@ -9,3 +9,13 @@ export function gridToCanvasCoordinates(x, y) {
         y: centerY - y  // Subtract y because canvas Y increases downwards
     }
 }
+
+export function canvasToGridCoordinates(x, y) {
+    const { width, height } = useCanvasDimensions().value
+    const centerX = Math.floor(width / 2)
+    const centerY = Math.floor(height / 2)
+    return {
+        x: x - centerX,
+        y: centerY - y  // Invert y because grid Y increases upwards
+    }
+}


### PR DESCRIPTION
Add force vectors to the grid and modify the head location by clicking+dragging an invisible point on the head. Eventually, the head will only snap to grid points.

Current issues:
- ~~Magnitude doesn't update as the vector head is dragged~~
- ~~using `gridToCanvasCoordinates` throws an error~~
- ~~Draggable area doesn't reset to vector head after mouseup~~. 
- ~~Either I'm confused about how to use `gridToCanvasCoordinates` or there's a bug. I don't think I'm doing something right with setting up the vector coordinates. Likely easier for us to discuss over zoom.~~ Still an issue, but we'll figure it out later.
- ~~Features merged from main (components and cumulative vector) are borked.~~

To-do:
- ~~snap vector head to grid points~~