### PR TITLE
feat: hide grid option, larger origin point

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -7,7 +7,9 @@
             <ClientOnly>
               <v-stage :config="configStage">
                 <v-layer>
-                  <Grid :spacing="50" />
+                  <Grid 
+                    :spacing="50" 
+                    :hideGrid="hideGrid"/>
                   <ForceVector v-for="vector in forceVectors" :key="vector.Grid"
                     :tail="vector.tail" 
                     :head="vector.head" 
@@ -23,7 +25,10 @@
             <ClientOnly>
               <v-stage :config="configStage">
                 <v-layer>
-                  <Grid :spacing="50" />
+                  <Grid 
+                    :spacing="50"
+                    :hideGrid="hideGrid" 
+                    />
                   <ForceVector v-for="vector in cumulativeVectors" 
                     :key="vector.id"
                     :tail="vector.tail" 
@@ -37,15 +42,22 @@
             </ClientOnly>
           </v-col>
         </v-row>
-        <v-btn @click="clearForceVectors">
-          Clear Vectors
-        </v-btn>
-        <v-btn @click="addForceVector">
-          Add Force Vector
-        </v-btn>
-        <v-checkbox
-          v-model="showComponents"
-          label="Show Vector Components"/>
+        <v-row>
+          <v-btn @click="clearForceVectors">
+            Clear Vectors
+          </v-btn>
+          <v-btn @click="addForceVector">
+            Add Force Vector
+          </v-btn>
+        </v-row>
+        <v-row>
+          <v-checkbox
+            v-model="showComponents"
+            label="Show Vector Components"/>
+          <v-checkbox
+          v-model="hideGrid"
+          label="Hide Grid"/>
+        </v-row>
       </v-container>
     </v-main>
   </v-app>
@@ -59,6 +71,7 @@ import ForceVector from '~/components/ForceVector.vue'
 import { provideCanvasDimensions } from '~/composables/useCanvasDimensions'
 
 const showComponents = ref(false) 
+const hideGrid = ref(false)
 
 const configStage = {
   width: 500,

--- a/components/Grid.vue
+++ b/components/Grid.vue
@@ -23,6 +23,7 @@
     height: { type: Number, default: 500 },
     spacing: { type: Number, default: 50 },
     dotRadius: { type: Number, default: 4 },
+    hideGrid: {type: Boolean, default: false}
   })
   
   const gridPoints = computed(() => {
@@ -30,11 +31,19 @@
     for (let x = -Math.floor(props.width / 2); x <= Math.floor(props.width / 2); x += props.spacing) {
       for (let y = -Math.floor(props.height / 2); y <= Math.floor(props.height / 2); y += props.spacing) {
         const { x: canvasX, y: canvasY } = gridToCanvasCoordinates(x, y, props.width, props.height)
+
+        let opacity = 1
+        if(props.hideGrid){
+          opacity = isOrigin(x,y)? 1: 0
+        }
+        
+        console.log(isOrigin(x,y))
         points.push({
           x: canvasX,
           y: canvasY,
-          radius: props.dotRadius,
-          fill: x === 0 && y === 0 ? 'red' : 'lightgray',
+          radius: isOrigin(x,y)? 8: props.dotRadius,
+          fill: isOrigin(x,y) ? 'black' : 'lightgray',
+          opacity: opacity,
         })
       }
     }
@@ -53,6 +62,10 @@
     fill: 'red',
   }
 })
+
+const isOrigin = (x, y) =>{
+  return x === 0 && y === 0
+}
  
 const axisLabels = computed(() => {
   const labels = []


### PR DESCRIPTION
Gives option to hide the grid points except the origin. We might want to allow it to be enabled/disabled for both grids though? That'd require a slight refactor, but I don't think it'd be too bad.